### PR TITLE
Add manuals stub, refactor export HTML, and scope fsr details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import {
   IssueCard,
   ManageDocsModal,
   ManageTypes,
+  ManualsModal,
   PhotoVault,
   SerialTagCard,
   ServiceSummaryForm,

--- a/src/components/ManualsModal.jsx
+++ b/src/components/ManualsModal.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { X, BookOpen } from "lucide-react";
+
+function ManualsModal({ open, onClose, model }) {
+  if (!open) return null;
+
+  const trimmedModel = (model || "").trim();
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <BookOpen size={20} />
+            <h3 className="text-xl font-bold">Owner's Manuals</h3>
+          </div>
+          <button className="p-2 rounded-full hover:bg-gray-100" onClick={onClose}>
+            <X size={18} />
+          </button>
+        </div>
+        <div className="space-y-3 text-sm text-gray-600">
+          <p>
+            Manuals will live here soon. In the meantime, reach out to the engineering team or check the shared drive
+            if you need documentation for this job.
+          </p>
+          <div className="rounded-xl border bg-gray-50 px-4 py-3 text-gray-700">
+            <div className="text-xs uppercase tracking-wide text-gray-500">Selected model</div>
+            <div className="font-semibold text-base">{trimmedModel || "Model not specified"}</div>
+          </div>
+        </div>
+        <div className="mt-6 flex justify-end">
+          <button className="px-4 py-2 rounded-xl border" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ManualsModal;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as DocumentTabs } from "./DocumentTabs.jsx";
 export { default as ManageTypes } from "./ManageTypes.jsx";
 export { default as ManageDocsModal } from "./ManageDocsModal.jsx";
 export { default as ConfirmDialog } from "./ConfirmDialog.jsx";
+export { default as ManualsModal } from "./ManualsModal.jsx";

--- a/src/utils/fsr.test.js
+++ b/src/utils/fsr.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildReportHtml } from "./fsr";
+
+const sampleReport = {
+  id: "r1",
+  jobNo: "J#1234",
+  tripType: "Service",
+  model: "M",
+  startAt: new Date("2024-01-01T08:00:00Z").toISOString(),
+  endAt: new Date("2024-01-01T10:00:00Z").toISOString(),
+  serialTagImageUrl: "data:image/png;base64,serial",
+  serialTagMissing: false,
+  documents: [
+    {
+      id: "d1",
+      name: "Field Service Report",
+      done: true,
+      data: {
+        issues: [
+          {
+            id: "i1",
+            note: "Cleared alarms & checked <safety>",
+            imageUrl: "data:image/png;base64,issue",
+            createdAt: new Date("2024-01-01T08:30:00Z").toISOString(),
+          },
+        ],
+      },
+    },
+  ],
+  photos: [
+    {
+      id: "p1",
+      imageUrl: "data:image/png;base64,photo",
+      caption: "Overview of lift",
+    },
+  ],
+};
+
+describe("buildReportHtml", () => {
+  it("creates a printable document with key sections", () => {
+    const html = buildReportHtml(sampleReport);
+
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain("Field Service Report");
+    expect(html).toContain(sampleReport.jobNo);
+    expect(html).toContain("Field Service Report – Issues");
+    expect(html).toContain("Field Pictures");
+    expect(html).toContain("Cleared alarms &amp; checked &lt;safety&gt;");
+  });
+});

--- a/src/utils/fsrDetails.test.js
+++ b/src/utils/fsrDetails.test.js
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { makeEmptyDetails, updateDetails } from "./fsrDetails";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearDetailsScope,
+  ensureDetailsScope,
+  makeEmptyDetails,
+  resetDetailsScopes,
+  setDetailsScope,
+  updateDetails,
+  updateDetailsInScope,
+} from "./fsrDetails";
+
+beforeEach(() => {
+  resetDetailsScopes();
+});
 
 describe("updateDetails", () => {
   it("updates the work summary without mutating the original", () => {
@@ -31,5 +43,33 @@ describe("updateDetails", () => {
 
     const removed = updateDetails(trimmed, { type: "removePartNeeded", id: trimmed.partsNeeded[0].id });
     expect(removed.partsNeeded.map((p) => p.text)).toEqual(["Control board"]);
+  });
+});
+
+describe("scoped fsrDetails", () => {
+  it("reuses the same details object within a scope", () => {
+    const a = ensureDetailsScope("job-1");
+    a.workSummary = "Initial";
+
+    const again = ensureDetailsScope("job-1");
+    expect(again).toBe(a);
+    expect(again.workSummary).toBe("Initial");
+
+    const other = ensureDetailsScope("job-2");
+    expect(other).not.toBe(a);
+  });
+
+  it("sets, updates, and clears scoped details", () => {
+    const stored = setDetailsScope("job-3", { workSummary: "Checked hydraulics" });
+    expect(stored.workSummary).toBe("Checked hydraulics");
+
+    const next = updateDetailsInScope("job-3", { type: "addPartInstalled", value: "Pump" });
+    expect(next.partsInstalled).toHaveLength(1);
+    expect(ensureDetailsScope("job-3")).toBe(next);
+
+    clearDetailsScope("job-3");
+    const afterClear = ensureDetailsScope("job-3");
+    expect(afterClear).not.toBe(next);
+    expect(afterClear.partsInstalled).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- add a placeholder ManualsModal component and wire it into the app shell
- refactor exportReport to use a buildReportHtml helper with consistent escaping
- add scoped fsr details helpers and accompanying tests including a smoke test for buildReportHtml

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1ef3cdde88323ac6375e8cd16789b