### PR TITLE
Add offline auth gate with user-scoped storage

### DIFF
--- a/src/auth/AuthContext.jsx
+++ b/src/auth/AuthContext.jsx
@@ -1,0 +1,209 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  createLocalAccount,
+  ensureDeviceSalt,
+  getCurrentUserId,
+  loadUsers,
+  migrateLegacyData,
+  removeCurrentUserId,
+  scopeStorageForUser,
+  setCurrentUserId,
+  signInWithPin,
+} from "../utils/auth";
+
+const AuthContext = createContext(null);
+
+const resolveBaseStorage = () => {
+  if (typeof window !== "undefined" && window.localStorage) return window.localStorage;
+  if (typeof globalThis !== "undefined" && globalThis.localStorage) return globalThis.localStorage;
+  const memory = new Map();
+  return {
+    getItem: (key) => (memory.has(key) ? memory.get(key) : null),
+    setItem: (key, value) => {
+      memory.set(key, String(value));
+    },
+    removeItem: (key) => {
+      memory.delete(key);
+    },
+    clear: () => memory.clear(),
+    key: (index) => Array.from(memory.keys())[index] ?? null,
+    get length() {
+      return memory.size;
+    },
+  };
+};
+
+export function AuthProvider({ children }) {
+  const storageRef = useRef(null);
+  if (storageRef.current === null) {
+    storageRef.current = resolveBaseStorage();
+  }
+  const baseStorage = storageRef.current;
+
+  const [status, setStatus] = useState("loading");
+  const [users, setUsers] = useState([]);
+  const [currentUser, setCurrentUser] = useState(null);
+  const [lockedUser, setLockedUser] = useState(null);
+  const [rememberSelection, setRememberSelection] = useState(true);
+  const [initialEmail, setInitialEmail] = useState("");
+  const [justSignedIn, setJustSignedIn] = useState(false);
+  const clearJustSignedIn = useCallback(() => setJustSignedIn(false), []);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        ensureDeviceSalt(baseStorage);
+        await migrateLegacyData(baseStorage);
+        const loadedUsers = loadUsers(baseStorage);
+        if (!mounted) return;
+        setUsers(loadedUsers);
+        const storedId = getCurrentUserId(baseStorage);
+        if (storedId) {
+          const existing = loadedUsers.find((user) => user.id === storedId);
+          if (existing) {
+            setCurrentUser(existing);
+            setInitialEmail(existing.email || "");
+            setStatus("ready");
+            setJustSignedIn(false);
+            return;
+          }
+          removeCurrentUserId(baseStorage);
+        }
+        setStatus("signedOut");
+      } catch (error) {
+        console.error("Failed to initialize auth", error);
+        if (mounted) {
+          setStatus("signedOut");
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [baseStorage]);
+
+  const scopedStorage = useMemo(() => {
+    if (!currentUser) return null;
+    return scopeStorageForUser(currentUser.id, baseStorage);
+  }, [baseStorage, currentUser]);
+
+  const handleSuccessfulAuth = ({ user, remember, snapshot }) => {
+    if (snapshot) {
+      setUsers(snapshot);
+    } else {
+      setUsers(loadUsers(baseStorage));
+    }
+    setCurrentUser(user);
+    setInitialEmail(user.email || "");
+    setLockedUser(null);
+    setStatus("ready");
+    setRememberSelection(remember);
+    setJustSignedIn(true);
+    if (remember) {
+      setCurrentUserId(user.id, baseStorage);
+    } else {
+      removeCurrentUserId(baseStorage);
+    }
+  };
+
+  const signIn = async ({ email, pin, remember }) => {
+    const result = await signInWithPin({ email, pin, storage: baseStorage });
+    if (!result.ok) {
+      if (result.error === "not-found") {
+        setInitialEmail(email.trim());
+      }
+      return result;
+    }
+    handleSuccessfulAuth({ user: result.user, remember, snapshot: result.users });
+    return { ok: true, user: result.user };
+  };
+
+  const createAccount = async ({ email, pin, name, remember }) => {
+    const result = await createLocalAccount({ email, pin, name, storage: baseStorage });
+    if (!result.ok) {
+      return result;
+    }
+    handleSuccessfulAuth({ user: result.user, remember, snapshot: result.users });
+    return { ok: true, user: result.user };
+  };
+
+  const signOut = () => {
+    setCurrentUser(null);
+    setLockedUser(null);
+    setStatus("signedOut");
+    removeCurrentUserId(baseStorage);
+    setJustSignedIn(false);
+    setInitialEmail("");
+  };
+
+  const lock = () => {
+    if (!currentUser) return;
+    setLockedUser(currentUser);
+    setInitialEmail(currentUser.email || "");
+    setCurrentUser(null);
+    setStatus("locked");
+    setJustSignedIn(false);
+    if (rememberSelection) {
+      setCurrentUserId(currentUser.id, baseStorage);
+    }
+  };
+
+  const switchUser = () => {
+    setCurrentUser(null);
+    setLockedUser(null);
+    setStatus("signedOut");
+    removeCurrentUserId(baseStorage);
+    setJustSignedIn(false);
+    setInitialEmail("");
+  };
+
+  const value = useMemo(
+    () => ({
+      status,
+      users,
+      currentUser,
+      scopedStorage,
+      rememberSelection,
+      setRememberSelection,
+      initialEmail,
+      lockedUser,
+      justSignedIn,
+      signIn,
+      createAccount,
+      signOut,
+      switchUser,
+      lock,
+      clearJustSignedIn,
+    }),
+    [
+      status,
+      users,
+      currentUser,
+      scopedStorage,
+      rememberSelection,
+      initialEmail,
+      lockedUser,
+      justSignedIn,
+      clearJustSignedIn,
+    ],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+};

--- a/src/auth/AuthGate.jsx
+++ b/src/auth/AuthGate.jsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Lock, LogIn, UserPlus } from "lucide-react";
+import { useAuth } from "./AuthContext";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const normalizeEmail = (value = "") => value.trim().toLowerCase();
+
+function PinInput({ value, onChange, disabled }) {
+  return (
+    <input
+      className="w-full rounded-xl border px-3 py-2"
+      type="password"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      maxLength={6}
+      placeholder="6-digit PIN"
+      value={value}
+      disabled={disabled}
+      onChange={(event) => {
+        const next = event.target.value.replace(/[^0-9]/g, "").slice(0, 6);
+        onChange(next);
+      }}
+    />
+  );
+}
+
+export default function AuthGate() {
+  const {
+    status,
+    signIn,
+    createAccount,
+    rememberSelection,
+    setRememberSelection,
+    initialEmail,
+    lockedUser,
+  } = useAuth();
+
+  const [mode, setMode] = useState("signIn");
+  const [email, setEmail] = useState(initialEmail || "");
+  const [pin, setPin] = useState("");
+  const [confirmPin, setConfirmPin] = useState("");
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState(null);
+
+  const isLocked = status === "locked";
+  const emailDisabled = isLocked && !!initialEmail;
+
+  useEffect(() => {
+    setEmail(initialEmail || "");
+    if (isLocked) {
+      setMode("signIn");
+    }
+  }, [initialEmail, isLocked]);
+
+  const canSubmitSignIn = normalizeEmail(email) && pin.length === 6;
+  const canSubmitCreate =
+    EMAIL_REGEX.test(normalizeEmail(email)) && pin.length === 6 && pin === confirmPin;
+
+  const heading = useMemo(() => {
+    if (isLocked) return "Unlock account";
+    return mode === "create" ? "Create account" : "Sign in";
+  }, [isLocked, mode]);
+
+  const subheading = useMemo(() => {
+    if (isLocked && lockedUser) {
+      return `Welcome back, ${lockedUser.name || lockedUser.email || "Field Tech"}`;
+    }
+    if (mode === "create") {
+      return "Create a local profile to save reports on this device.";
+    }
+    return "Use your work email and offline PIN.";
+  }, [isLocked, lockedUser, mode]);
+
+  const handleSignIn = async (event) => {
+    event.preventDefault();
+    if (!canSubmitSignIn) return;
+    setLoading(true);
+    setMessage(null);
+    const result = await signIn({ email, pin, remember: rememberSelection });
+    setLoading(false);
+    if (!result.ok) {
+      if (result.error === "not-found") {
+        setMessage({ type: "info", text: "No local account found. Sign in requires internet for first time." });
+      } else if (result.error === "invalid-pin") {
+        setMessage({ type: "error", text: "Incorrect PIN. Try again." });
+      } else if (result.error === "throttled") {
+        const retryIn = Math.max(0, Math.ceil((result.retryAt - Date.now()) / 1000));
+        setMessage({ type: "error", text: `Too many attempts. Try again in ${retryIn}s.` });
+      } else {
+        setMessage({ type: "error", text: "Unable to sign in offline." });
+      }
+      if (result.error !== "throttled") {
+        setPin("");
+      }
+      return;
+    }
+    setPin("");
+    setMessage(null);
+  };
+
+  const handleCreateAccount = async (event) => {
+    event.preventDefault();
+    if (!canSubmitCreate) return;
+    setLoading(true);
+    setMessage(null);
+    const result = await createAccount({ email, pin, name, remember: rememberSelection });
+    setLoading(false);
+    if (!result.ok) {
+      if (result.error === "duplicate-email") {
+        setMessage({ type: "error", text: "An account with that email already exists on this device." });
+      } else {
+        setMessage({ type: "error", text: "Unable to create account offline." });
+      }
+      return;
+    }
+    setPin("");
+    setConfirmPin("");
+    setName("");
+    setMessage(null);
+  };
+
+  const handleSubmit = mode === "create" ? handleCreateAccount : handleSignIn;
+
+  return (
+    <div className="min-h-dvh bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center px-4 py-8">
+      <div className="w-full max-w-md rounded-3xl bg-white/95 shadow-xl p-8">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-3 rounded-2xl bg-blue-100 text-blue-700">
+            {mode === "create" ? <UserPlus size={20} /> : <Lock size={20} />}
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">{heading}</h1>
+            <p className="text-sm text-slate-500">{subheading}</p>
+          </div>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-700" htmlFor="auth-email">
+              Work email
+            </label>
+            <input
+              id="auth-email"
+              className="w-full rounded-xl border px-3 py-2"
+              type="email"
+              autoComplete="email"
+              placeholder="tech@example.com"
+              value={email}
+              disabled={emailDisabled}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-700" htmlFor="auth-pin">
+              Offline PIN
+            </label>
+            <PinInput value={pin} onChange={setPin} disabled={loading} />
+            <p className="text-xs text-slate-500">6 digits — stored securely on this device only.</p>
+          </div>
+
+          {mode === "create" && (
+            <>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-700" htmlFor="auth-confirm-pin">
+                  Confirm PIN
+                </label>
+                <PinInput value={confirmPin} onChange={setConfirmPin} disabled={loading} />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-700" htmlFor="auth-name">
+                  Display name <span className="text-xs text-slate-400">(optional)</span>
+                </label>
+                <input
+                  id="auth-name"
+                  className="w-full rounded-xl border px-3 py-2"
+                  placeholder="Field Tech"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          <label className="flex items-center gap-2 text-sm text-slate-600">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border"
+              checked={rememberSelection}
+              onChange={(event) => setRememberSelection(event.target.checked)}
+            />
+            Remember me on this device
+          </label>
+
+          {message && (
+            <div
+              className={`rounded-xl border px-3 py-2 text-sm ${
+                message.type === "error"
+                  ? "border-red-200 bg-red-50 text-red-700"
+                  : "border-blue-200 bg-blue-50 text-blue-700"
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="w-full flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-4 py-2 text-white font-semibold disabled:opacity-50"
+            disabled={loading || (mode === "create" ? !canSubmitCreate : !canSubmitSignIn)}
+          >
+            {mode === "create" ? <UserPlus size={18} /> : <LogIn size={18} />}
+            {mode === "create" ? "Create account" : isLocked ? "Unlock" : "Sign in"}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center text-sm text-slate-600">
+          {mode === "create" ? (
+            <button
+              className="text-blue-600 font-medium hover:underline"
+              onClick={() => {
+                setMode("signIn");
+                setMessage(null);
+                setPin("");
+                setConfirmPin("");
+              }}
+            >
+              Already have an account? Sign in
+            </button>
+          ) : (
+            <button
+              className="text-blue-600 font-medium hover:underline"
+              onClick={() => {
+                setMode("create");
+                setMessage(null);
+                setPin("");
+                setConfirmPin("");
+              }}
+            >
+              Need an account? Create one
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ManageTypes.jsx
+++ b/src/components/ManageTypes.jsx
@@ -3,7 +3,7 @@ import { X } from "lucide-react";
 import { saveTypes } from "../utils/fsr";
 import useModalA11y from "../hooks/useModalA11y";
 
-function ManageTypes({ open, onClose, types, setTypes, returnFocusRef }) {
+function ManageTypes({ open, onClose, types, setTypes, returnFocusRef, storage }) {
   const [newType, setNewType] = useState("");
   const containerRef = useRef(null);
   useModalA11y(open, containerRef, { onClose, returnFocusRef });
@@ -30,7 +30,7 @@ function ManageTypes({ open, onClose, types, setTypes, returnFocusRef }) {
                 onClick={() => {
                   const up = types.filter((_, i) => i !== idx);
                   setTypes(up);
-                  saveTypes(up);
+                  saveTypes(up, storage);
                 }}
               >
                 Remove
@@ -54,7 +54,7 @@ function ManageTypes({ open, onClose, types, setTypes, returnFocusRef }) {
               if (types.includes(v)) return;
               const up = [...types, v];
               setTypes(up);
-              saveTypes(up);
+              saveTypes(up, storage);
               setNewType("");
             }}
           >

--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useRef, useState } from "react";
+import { ChevronDown, LogOut, RefreshCcw, Shield, Users } from "lucide-react";
+
+function MenuItem({ icon: Icon, label, onClick, disabled }) {
+  return (
+    <button
+      className={`w-full flex items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${
+        disabled ? "cursor-not-allowed text-slate-400" : "hover:bg-slate-100 text-slate-700"
+      }`}
+      onClick={onClick}
+      type="button"
+      disabled={disabled}
+    >
+      <Icon size={16} />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export default function UserMenu({ user, onLock, onSignOut, onSwitchUser, onSync }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const handleClick = (event) => {
+      if (!open) return;
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [open]);
+
+  const online = typeof navigator !== "undefined" ? navigator.onLine : false;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        className="flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium text-slate-700 bg-white shadow-sm hover:bg-slate-50"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <div className="text-left">
+          <div className="font-semibold leading-tight">{user.name || "Field Tech"}</div>
+          <div className="text-xs text-slate-500">{user.email}</div>
+        </div>
+        <ChevronDown size={16} className="text-slate-400" />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-56 rounded-xl border bg-white p-3 shadow-xl z-20">
+          <div className="mb-2 text-xs uppercase tracking-wide text-slate-400">Account</div>
+          <MenuItem
+            icon={RefreshCcw}
+            label="Sync (coming soon)"
+            disabled={!online}
+            onClick={() => {
+              if (!online) return;
+              onSync?.();
+              setOpen(false);
+            }}
+          />
+          <MenuItem
+            icon={Users}
+            label="Switch user"
+            onClick={() => {
+              onSwitchUser?.();
+              setOpen(false);
+            }}
+          />
+          <MenuItem
+            icon={Shield}
+            label="Lock"
+            onClick={() => {
+              onLock?.();
+              setOpen(false);
+            }}
+          />
+          <MenuItem
+            icon={LogOut}
+            label="Sign out"
+            onClick={() => {
+              onSignOut?.();
+              setOpen(false);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as ManualsModal } from "./ManualsModal.jsx";
 export { default as FsrEntriesSection } from "./FsrEntriesSection.jsx";
 export { default as MultiPhotoUpload } from "./MultiPhotoUpload.jsx";
 export { default as StorageMeter } from "./StorageMeter.jsx";
+export { default as UserMenu } from "./UserMenu.jsx";

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,269 @@
+import { uid } from "./id";
+import { createScopedStorage, hasUserScopedData, listGlobalFsrKeys, toScopedKey } from "./storage";
+
+export const USERS_KEY = "fsr.users";
+export const CURRENT_USER_KEY = "fsr.currentUserId";
+export const DEVICE_SALT_KEY = "fsr.deviceSalt";
+
+const LOCKOUT_THRESHOLD = 3;
+export const LOCKOUT_DURATION_MS = 10_000;
+
+const attemptState = new Map();
+
+const resolveStorage = (storage) => {
+  if (storage) return storage;
+  if (typeof window !== "undefined" && window.localStorage) return window.localStorage;
+  if (typeof globalThis !== "undefined" && globalThis.localStorage) return globalThis.localStorage;
+  throw new Error("localStorage is not available");
+};
+
+const getCrypto = () => {
+  if (typeof globalThis !== "undefined" && globalThis.crypto) return globalThis.crypto;
+  if (typeof window !== "undefined" && window.crypto) return window.crypto;
+  throw new Error("Web Crypto API is not available");
+};
+
+const encoder = new TextEncoder();
+
+const encodeBase64 = (buffer) => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  if (typeof btoa === "function") {
+    return btoa(binary);
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(binary, "binary").toString("base64");
+  }
+  throw new Error("Base64 encoding is not supported in this environment");
+};
+
+const randomBytesBase64 = (size = 16) => {
+  const arr = new Uint8Array(size);
+  getCrypto().getRandomValues(arr);
+  return encodeBase64(arr);
+};
+
+const normalizeEmail = (email = "") => email.trim().toLowerCase();
+
+export const ensureDeviceSalt = (storage) => {
+  const backing = resolveStorage(storage);
+  let salt = backing.getItem(DEVICE_SALT_KEY);
+  if (salt) return salt;
+  salt = randomBytesBase64(16);
+  backing.setItem(DEVICE_SALT_KEY, salt);
+  return salt;
+};
+
+export const hashPin = async (deviceSalt, email, pin) => {
+  const normalizedEmail = normalizeEmail(email);
+  const normalizedPin = String(pin ?? "").trim();
+  const payload = `${deviceSalt}:${normalizedEmail}:${normalizedPin}`;
+  const digest = await getCrypto().subtle.digest("SHA-256", encoder.encode(payload));
+  return encodeBase64(digest);
+};
+
+export const loadUsers = (storage) => {
+  const backing = resolveStorage(storage);
+  try {
+    const raw = backing.getItem(USERS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+    return [];
+  } catch (error) {
+    console.error("Failed to parse local users", error);
+    return [];
+  }
+};
+
+export const saveUsers = (users, storage) => {
+  const backing = resolveStorage(storage);
+  backing.setItem(USERS_KEY, JSON.stringify(users));
+};
+
+export const getCurrentUserId = (storage) => {
+  const backing = resolveStorage(storage);
+  return backing.getItem(CURRENT_USER_KEY);
+};
+
+export const setCurrentUserId = (userId, storage) => {
+  const backing = resolveStorage(storage);
+  if (!userId) {
+    backing.removeItem(CURRENT_USER_KEY);
+  } else {
+    backing.setItem(CURRENT_USER_KEY, userId);
+  }
+};
+
+export const createUserRecord = async ({ email, pin, name, storage }) => {
+  const backing = resolveStorage(storage);
+  const deviceSalt = ensureDeviceSalt(backing);
+  const normalizedEmail = normalizeEmail(email);
+  const now = new Date().toISOString();
+  const pinHash = await hashPin(deviceSalt, normalizedEmail, pin);
+  const salt = randomBytesBase64(16);
+  const cryptoRef = getCrypto();
+  const id = typeof cryptoRef.randomUUID === "function" ? cryptoRef.randomUUID() : `user_${uid()}`;
+  return {
+    id,
+    email: normalizedEmail,
+    name: (name || "").trim(),
+    pinHash,
+    salt,
+    createdAt: now,
+    lastLoginAt: now,
+  };
+};
+
+export const findUserByEmail = (email, users) => {
+  const normalizedEmail = normalizeEmail(email);
+  return users.find((user) => normalizeEmail(user.email) === normalizedEmail) || null;
+};
+
+const getAttemptState = (email) => {
+  const normalized = normalizeEmail(email);
+  const existing = attemptState.get(normalized);
+  if (existing) return existing;
+  const fresh = { attempts: 0, lockedUntil: 0 };
+  attemptState.set(normalized, fresh);
+  return fresh;
+};
+
+export const resetAuthThrottle = () => {
+  attemptState.clear();
+};
+
+const registerFailure = (email) => {
+  const state = getAttemptState(email);
+  const now = Date.now();
+  if (state.lockedUntil && now >= state.lockedUntil) {
+    state.lockedUntil = 0;
+    state.attempts = 0;
+  }
+  state.attempts += 1;
+  if (state.attempts >= LOCKOUT_THRESHOLD) {
+    state.lockedUntil = now + LOCKOUT_DURATION_MS;
+    state.attempts = 0;
+  }
+  return state.lockedUntil ? { lockedUntil: state.lockedUntil } : null;
+};
+
+const clearFailures = (email) => {
+  const normalized = normalizeEmail(email);
+  attemptState.delete(normalized);
+};
+
+export const signInWithPin = async ({ email, pin, storage }) => {
+  const backing = resolveStorage(storage);
+  const normalizedEmail = normalizeEmail(email);
+  const state = getAttemptState(normalizedEmail);
+  const now = Date.now();
+  if (state.lockedUntil && now < state.lockedUntil) {
+    return { ok: false, error: "throttled", retryAt: state.lockedUntil };
+  }
+
+  const users = loadUsers(backing);
+  const user = findUserByEmail(normalizedEmail, users);
+  if (!user) {
+    registerFailure(normalizedEmail);
+    return { ok: false, error: "not-found" };
+  }
+  if (!user.pinHash) {
+    clearFailures(normalizedEmail);
+    return { ok: true, user, users };
+  }
+
+  const deviceSalt = ensureDeviceSalt(backing);
+  const attemptHash = await hashPin(deviceSalt, normalizedEmail, pin);
+  if (attemptHash !== user.pinHash) {
+    const throttle = registerFailure(normalizedEmail);
+    if (throttle) {
+      return { ok: false, error: "throttled", retryAt: throttle.lockedUntil };
+    }
+    return { ok: false, error: "invalid-pin" };
+  }
+
+  clearFailures(normalizedEmail);
+  const nextUsers = users.map((entry) =>
+    entry.id === user.id ? { ...entry, lastLoginAt: new Date().toISOString() } : entry,
+  );
+  saveUsers(nextUsers, backing);
+  const refreshedUser = nextUsers.find((entry) => entry.id === user.id) || user;
+  return { ok: true, user: refreshedUser, users: nextUsers };
+};
+
+export const createLocalAccount = async ({ email, pin, storage, name }) => {
+  const backing = resolveStorage(storage);
+  const normalizedEmail = normalizeEmail(email);
+  const users = loadUsers(backing);
+  if (findUserByEmail(normalizedEmail, users)) {
+    return { ok: false, error: "duplicate-email" };
+  }
+  const user = await createUserRecord({ email: normalizedEmail, pin, name, storage: backing });
+  const nextUsers = [...users, user];
+  saveUsers(nextUsers, backing);
+  clearFailures(normalizedEmail);
+  return { ok: true, user, users: nextUsers };
+};
+
+export const migrateLegacyData = async (storage) => {
+  const backing = resolveStorage(storage);
+  const globalKeys = listGlobalFsrKeys(backing);
+  if (!globalKeys.length) {
+    return { migrated: false, userCreated: false };
+  }
+
+  if (hasUserScopedData(backing)) {
+    globalKeys.forEach((key) => backing.removeItem(key));
+    return { migrated: true, userCreated: false };
+  }
+
+  const deviceSalt = ensureDeviceSalt(backing);
+  const users = loadUsers(backing);
+  let defaultUser = users.find((user) => user.id === "local-default");
+  let userCreated = false;
+
+  if (!defaultUser) {
+    const defaultPin = "000000";
+    const pinHash = await hashPin(deviceSalt, "(local)", defaultPin);
+    defaultUser = {
+      id: "local-default",
+      email: "(local)",
+      name: "Local Tech",
+      pinHash,
+      salt: randomBytesBase64(16),
+      createdAt: new Date().toISOString(),
+      lastLoginAt: new Date().toISOString(),
+    };
+    users.push(defaultUser);
+    userCreated = true;
+    saveUsers(users, backing);
+  }
+
+  globalKeys.forEach((key) => {
+    const targetKey = toScopedKey(key, defaultUser.id);
+    if (backing.getItem(targetKey) === null) {
+      const value = backing.getItem(key);
+      if (value !== null) {
+        backing.setItem(targetKey, value);
+      }
+    }
+    backing.removeItem(key);
+  });
+
+  if (!backing.getItem(CURRENT_USER_KEY)) {
+    backing.setItem(CURRENT_USER_KEY, defaultUser.id);
+  }
+
+  return { migrated: true, userCreated };
+};
+
+export const removeCurrentUserId = (storage) => {
+  const backing = resolveStorage(storage);
+  backing.removeItem(CURRENT_USER_KEY);
+};
+
+export const scopeStorageForUser = (userId, storage) => createScopedStorage(userId, resolveStorage(storage));

--- a/src/utils/auth.test.js
+++ b/src/utils/auth.test.js
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LOCKOUT_DURATION_MS,
+  createLocalAccount,
+  getCurrentUserId,
+  hashPin,
+  loadUsers,
+  migrateLegacyData,
+  resetAuthThrottle,
+  signInWithPin,
+} from "./auth";
+import { loadReports, loadTypes } from "./fsr";
+import { createScopedStorage } from "./storage";
+
+const createMemoryStorage = () => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+const createReport = (id) => ({ id, jobNo: `J#${id}`, tripType: "Service", model: "A" });
+
+describe("auth.hashPin", () => {
+  it("produces deterministic hashes for the same input", async () => {
+    const hashA = await hashPin("device-salt", "tech@example.com", "123456");
+    const hashB = await hashPin("device-salt", "tech@example.com", "123456");
+    expect(hashA).toBe(hashB);
+  });
+
+  it("varies hash when email or pin changes", async () => {
+    const base = await hashPin("device-salt", "tech@example.com", "123456");
+    const differentEmail = await hashPin("device-salt", "other@example.com", "123456");
+    const differentPin = await hashPin("device-salt", "tech@example.com", "654321");
+    expect(base).not.toBe(differentEmail);
+    expect(base).not.toBe(differentPin);
+  });
+});
+
+describe("auth.migration", () => {
+  it("moves global data into a default local user namespace", async () => {
+    const storage = createMemoryStorage();
+    storage.setItem("fsr.deviceSalt", "device-salt");
+    storage.setItem("fsr.reports", JSON.stringify([createReport("001")]));
+    storage.setItem("fsr.tripTypes", JSON.stringify(["Service", "Warranty"]));
+
+    const result = await migrateLegacyData(storage);
+    expect(result.migrated).toBe(true);
+
+    const scopedReports = storage.getItem("fsr.local-default.reports");
+    const scopedTypes = storage.getItem("fsr.local-default.tripTypes");
+    expect(scopedReports).toBeTruthy();
+    expect(scopedTypes).toBeTruthy();
+    expect(storage.getItem("fsr.reports")).toBeNull();
+    expect(storage.getItem("fsr.tripTypes")).toBeNull();
+
+    const users = loadUsers(storage);
+    const defaultUser = users.find((user) => user.id === "local-default");
+    expect(defaultUser).toBeTruthy();
+    expect(getCurrentUserId(storage)).toBe("local-default");
+
+    const scoped = createScopedStorage("local-default", storage);
+    const reports = loadReports(scoped);
+    const types = loadTypes(scoped);
+    expect(reports).toHaveLength(1);
+    expect(types).toContain("Warranty");
+  });
+});
+
+describe("auth.signIn", () => {
+  let storage;
+
+  beforeEach(async () => {
+    storage = createMemoryStorage();
+    storage.setItem("fsr.deviceSalt", "static-salt");
+    resetAuthThrottle();
+    const createResult = await createLocalAccount({
+      email: "tech@example.com",
+      pin: "123456",
+      name: "Field Tech",
+      storage,
+    });
+    expect(createResult.ok).toBe(true);
+  });
+
+  afterEach(() => {
+    resetAuthThrottle();
+    vi.useRealTimers();
+  });
+
+  it("authenticates with the correct PIN and updates last login", async () => {
+    const result = await signInWithPin({ email: "tech@example.com", pin: "123456", storage });
+    expect(result.ok).toBe(true);
+    const updated = loadUsers(storage).find((user) => user.email === "tech@example.com");
+    expect(updated?.lastLoginAt).toBeTruthy();
+  });
+
+  it("rejects incorrect PIN attempts", async () => {
+    const result = await signInWithPin({ email: "tech@example.com", pin: "000000", storage });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("invalid-pin");
+  });
+
+  it("throttles repeated failures after three attempts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z"));
+
+    await signInWithPin({ email: "tech@example.com", pin: "000000", storage });
+    await signInWithPin({ email: "tech@example.com", pin: "000000", storage });
+    const third = await signInWithPin({ email: "tech@example.com", pin: "000000", storage });
+    expect(third.ok).toBe(false);
+    expect(third.error).toBe("throttled");
+    expect(third.retryAt).toBe(Date.now() + LOCKOUT_DURATION_MS);
+
+    vi.setSystemTime(new Date(Date.now() + LOCKOUT_DURATION_MS + 1));
+    const success = await signInWithPin({ email: "tech@example.com", pin: "123456", storage });
+    expect(success.ok).toBe(true);
+  });
+});

--- a/src/utils/fsr.test.js
+++ b/src/utils/fsr.test.js
@@ -228,4 +228,11 @@ describe("buildReportHtml", () => {
     const matches = html.match(/Correction photo \d+/g) || [];
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
+
+  it("injects current user details into the header", () => {
+    const report = makeReport([]);
+    const html = buildReportHtml(report, { name: "Alex Tech", email: "alex@pflow.com" });
+    expect(html).toContain("Alex Tech — Field Service Tech");
+    expect(html).toContain("alex@pflow.com");
+  });
 });

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,71 @@
+const RESERVED_KEYS = new Set(["fsr.users", "fsr.deviceSalt", "fsr.currentUserId"]);
+
+const SCOPE_PREFIX = "fsr.";
+
+const resolveStorage = (storage) => {
+  if (storage) return storage;
+  if (typeof window !== "undefined" && window.localStorage) return window.localStorage;
+  if (typeof globalThis !== "undefined" && globalThis.localStorage) return globalThis.localStorage;
+  return null;
+};
+
+export const toScopedKey = (key, userId) => {
+  if (!key.startsWith(SCOPE_PREFIX)) return key;
+  if (RESERVED_KEYS.has(key)) return key;
+  const segments = key.split(".");
+  if (segments.length >= 3) {
+    return key;
+  }
+  if (!userId) return key;
+  const suffix = segments.slice(1).join(".");
+  return `${SCOPE_PREFIX}${userId}.${suffix}`;
+};
+
+export const createScopedStorage = (userId, storage) => {
+  const backing = resolveStorage(storage);
+  if (!backing) {
+    throw new Error("localStorage is not available in this environment");
+  }
+  return {
+    scopeId: userId || "",
+    key: (rawKey) => toScopedKey(rawKey, userId),
+    getItem: (rawKey) => backing.getItem(toScopedKey(rawKey, userId)),
+    setItem: (rawKey, value) => backing.setItem(toScopedKey(rawKey, userId), value),
+    removeItem: (rawKey) => backing.removeItem(toScopedKey(rawKey, userId)),
+    clear: () => backing.clear(),
+    backing,
+  };
+};
+
+export const listGlobalFsrKeys = (storage) => {
+  const backing = resolveStorage(storage);
+  if (!backing) return [];
+  const keys = [];
+  for (let i = 0; i < backing.length; i += 1) {
+    const key = backing.key(i);
+    if (!key) continue;
+    if (!key.startsWith(SCOPE_PREFIX)) continue;
+    if (RESERVED_KEYS.has(key)) continue;
+    const segments = key.split(".");
+    if (segments.length === 2) {
+      keys.push(key);
+    }
+  }
+  return keys;
+};
+
+export const hasUserScopedData = (storage) => {
+  const backing = resolveStorage(storage);
+  if (!backing) return false;
+  for (let i = 0; i < backing.length; i += 1) {
+    const key = backing.key(i);
+    if (!key) continue;
+    if (!key.startsWith(SCOPE_PREFIX)) continue;
+    if (RESERVED_KEYS.has(key)) continue;
+    const segments = key.split(".");
+    if (segments.length >= 3) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createScopedStorage, toScopedKey } from "./storage";
+
+const createMemoryStorage = () => {
+  const store = new Map();
+  return {
+    getItem: (key) => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+describe("storage.scoped", () => {
+  it("prefixes fsr keys with the active user id", () => {
+    const base = createMemoryStorage();
+    const scopedA = createScopedStorage("user-a", base);
+    const scopedB = createScopedStorage("user-b", base);
+
+    scopedA.setItem("fsr.reports", "alpha");
+    scopedB.setItem("fsr.reports", "bravo");
+
+    expect(base.getItem("fsr.user-a.reports")).toBe("alpha");
+    expect(base.getItem("fsr.user-b.reports")).toBe("bravo");
+    expect(scopedA.getItem("fsr.reports")).toBe("alpha");
+    expect(scopedB.getItem("fsr.reports")).toBe("bravo");
+  });
+
+  it("respects reserved keys without additional scoping", () => {
+    const base = createMemoryStorage();
+    const scoped = createScopedStorage("user-a", base);
+    scoped.setItem("fsr.currentUserId", "user-a");
+    expect(base.getItem("fsr.currentUserId")).toBe("user-a");
+  });
+
+  it("exposes helper key conversion", () => {
+    expect(toScopedKey("fsr.tripTypes", "user-a")).toBe("fsr.user-a.tripTypes");
+    expect(toScopedKey("app.settings", "user-a")).toBe("app.settings");
+  });
+});


### PR DESCRIPTION
## Summary
- add an AuthProvider and AuthGate that keep track of remembered users, offline PIN verification, and lock/switch flows
- migrate legacy fsr.* keys into per-user namespaces and persist reports/types against the signed-in tech
- refresh the app chrome with a user menu, sync placeholder, offline empty-state banner, and user details in exported reports

## Testing
- npm test -- --run
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2acd3917c83239a04a617e2e42c5e