### PR TITLE
Fix focus loss caused by remounting inputs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -120,15 +120,28 @@ function Workspace({
     }
   }, [reports.length]);
 
-  // When selecting a report, default the active tab to the first document
-  useEffect(()=>{
-    if (selected) {
-      const first = selected.documents?.[0]?.id || null;
-      setActiveDocId(prev => selected.documents?.some(d=>d.id===prev) ? prev : first);
-    } else {
+  // Keep the active document stable and only reset when the previous tab disappears
+  const docIdsSignature = (selected?.documents || []).map((doc) => doc.id).join("|");
+  useEffect(() => {
+    if (!selected) {
       setActiveDocId(null);
+      return;
     }
-  }, [selectedId]);
+
+    const docs = selected.documents || [];
+    if (docs.length === 0) {
+      setActiveDocId(null);
+      return;
+    }
+
+    const firstDocId = docs[0]?.id || null;
+    setActiveDocId((prev) => {
+      if (prev && docs.some((doc) => doc.id === prev)) {
+        return prev;
+      }
+      return firstDocId;
+    });
+  }, [selected?.id, docIdsSignature]);
 
   const canCreate = isValidJob(jobNo) && !!tripType && !!model && new Date(endAt) >= new Date(startAt);
 

--- a/src/components/FsrEntriesSection.jsx
+++ b/src/components/FsrEntriesSection.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
@@ -70,6 +70,8 @@ const Label = ({ children }) => (
   <div className="text-xs font-semibold text-gray-600 mb-1 uppercase tracking-wide">{children}</div>
 );
 
+const createEmptyPartRow = () => ({ id: uid(), partNo: "", desc: "", qty: "" });
+
 const createDraft = (type) => {
   switch (type) {
     case "issue":
@@ -80,7 +82,7 @@ const createDraft = (type) => {
       return {
         type,
         note: "",
-        parts: [{ id: uid(), partNo: "", desc: "", qty: "" }],
+        parts: [createEmptyPartRow()],
         collapsed: true,
       };
     case "docRequest":
@@ -134,6 +136,11 @@ const getEntrySummary = (entry) => {
 
 function EntryForm({ value, onChange }) {
   const meta = FSR_ENTRY_TYPE_META[value.type] || { label: "Entry" };
+  const fallbackPartRowRef = useRef(createEmptyPartRow());
+
+  useEffect(() => {
+    fallbackPartRowRef.current = createEmptyPartRow();
+  }, [value.id]);
 
   if (value.type === "issue") {
     return (
@@ -182,7 +189,7 @@ function EntryForm({ value, onChange }) {
   }
 
   if (value.type === "orderParts") {
-    const parts = value.parts && value.parts.length ? value.parts : [{ id: uid(), partNo: "", desc: "", qty: "" }];
+    const parts = value.parts && value.parts.length ? value.parts : [fallbackPartRowRef.current];
     const updatePart = (index, patch) => {
       const next = parts.map((row, idx) => (idx === index ? { ...row, ...patch } : row));
       onChange({ ...value, parts: next });
@@ -192,7 +199,7 @@ function EntryForm({ value, onChange }) {
       onChange({ ...value, parts: next });
     };
     const addPart = () => {
-      onChange({ ...value, parts: [...parts, { id: uid(), partNo: "", desc: "", qty: "" }] });
+      onChange({ ...value, parts: [...parts, createEmptyPartRow()] });
     };
     return (
       <div className="space-y-4">
@@ -213,7 +220,7 @@ function EntryForm({ value, onChange }) {
             <div className="col-span-12 md:col-span-2">Qty</div>
           </div>
           {parts.map((row, index) => (
-            <div key={row.id || index} className="grid grid-cols-12 gap-2 px-3 py-2 border-t">
+            <div key={row.id} className="grid grid-cols-12 gap-2 px-3 py-2 border-t">
               <input
                 className="col-span-12 md:col-span-3 rounded-xl border px-3 py-2 text-sm"
                 value={row.partNo}

--- a/src/utils/fsr.test.js
+++ b/src/utils/fsr.test.js
@@ -128,6 +128,25 @@ describe("entry helpers", () => {
     expect(data.details.partsNeeded.map((item) => item.text)).toContain("123 — Photo eye (Qty 2)");
     expect(data.details.partsNeeded.map((item) => item.text)).toContain("456 — Controller (Qty 1)");
   });
+
+  it("assigns stable ids to order parts entries and rows when missing", () => {
+    const normalized = ensureFsrDocData({
+      entries: [
+        {
+          type: "orderParts",
+          parts: [{ partNo: "789", desc: "Valve", qty: "1" }],
+        },
+      ],
+    });
+
+    const entry = normalized.entries[0];
+    expect(entry.id).toBeTruthy();
+    expect(entry.parts[0].id).toBeTruthy();
+
+    const roundTrip = ensureFsrDocData(normalized);
+    expect(roundTrip.entries[0].id).toBe(entry.id);
+    expect(roundTrip.entries[0].parts[0].id).toBe(entry.parts[0].id);
+  });
 });
 
 describe("mergePartsNeeded", () => {


### PR DESCRIPTION
## Summary
- ensure order parts rows always have stable ids and reuse a fallback row instead of regenerating keys
- stop resetting the active document tab unless the previous selection disappears to prevent unnecessary remounts
- add a regression test that verifies ids are assigned to order parts entries and rows

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e2fe9557488323b6f892ff51100f2f