### PR TITLE
Add developer tool to clear local data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,7 @@ function Workspace({
   onSwitchUser,
   justSignedIn,
   clearJustSignedIn,
+  onResetApp,
 }) {
   const [types, setTypes] = useState(() => loadTypes(storage));
   const [manageOpen, setManageOpen] = useState(false);
@@ -74,6 +75,7 @@ function Workspace({
   // Delete confirm state
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [duplicatePrompt, setDuplicatePrompt] = useState(null);
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
 
   const [toast, setToast] = useState(null);
   const [banner, setBanner] = useState("");
@@ -83,6 +85,7 @@ function Workspace({
   const manualsTriggerRef = useRef(null);
   const setupTriggerRef = useRef(null);
   const deleteTriggerRef = useRef(null);
+  const resetTriggerRef = useRef(null);
 
   const storageScope = storage?.scopeId || "";
 
@@ -477,6 +480,8 @@ function Workspace({
                 onSignOut={onSignOut}
                 onSwitchUser={onSwitchUser}
                 onSync={handleSync}
+                onClearLocalData={() => setResetConfirmOpen(true)}
+                clearDataButtonRef={resetTriggerRef}
               />
             </div>
           </div>
@@ -660,6 +665,19 @@ function Workspace({
         />
       )}
 
+      <ConfirmDialog
+        open={resetConfirmOpen}
+        title="Reset app data?"
+        message="This will permanently remove all saved reports, photos, and user profiles from this device."
+        onCancel={() => setResetConfirmOpen(false)}
+        onConfirm={() => {
+          setResetConfirmOpen(false);
+          onResetApp?.();
+        }}
+        confirmText="Clear data"
+        returnFocusRef={resetTriggerRef}
+      />
+
       {/* Delete confirmation */}
       <ConfirmDialog
         open={!!deleteTarget}
@@ -710,7 +728,17 @@ function Workspace({
 }
 
 function AppShell() {
-  const { status, currentUser, scopedStorage, lock, signOut, switchUser, justSignedIn, clearJustSignedIn } = useAuth();
+  const {
+    status,
+    currentUser,
+    scopedStorage,
+    lock,
+    signOut,
+    switchUser,
+    justSignedIn,
+    clearJustSignedIn,
+    resetAppData,
+  } = useAuth();
 
   if (status === "loading") {
     return (
@@ -733,6 +761,7 @@ function AppShell() {
       onSwitchUser={switchUser}
       justSignedIn={justSignedIn}
       clearJustSignedIn={clearJustSignedIn}
+      onResetApp={resetAppData}
     />
   );
 }

--- a/src/auth/AuthContext.jsx
+++ b/src/auth/AuthContext.jsx
@@ -14,6 +14,7 @@ import {
   loadUsers,
   migrateLegacyData,
   removeCurrentUserId,
+  resetAuthThrottle,
   scopeStorageForUser,
   setCurrentUserId,
   signInWithPin,
@@ -56,6 +57,18 @@ export function AuthProvider({ children }) {
   const [initialEmail, setInitialEmail] = useState("");
   const [justSignedIn, setJustSignedIn] = useState(false);
   const clearJustSignedIn = useCallback(() => setJustSignedIn(false), []);
+
+  const resetAppData = useCallback(() => {
+    baseStorage.clear();
+    resetAuthThrottle();
+    setUsers([]);
+    setCurrentUser(null);
+    setLockedUser(null);
+    setRememberSelection(true);
+    setInitialEmail("");
+    setStatus("signedOut");
+    setJustSignedIn(false);
+  }, [baseStorage]);
 
   useEffect(() => {
     let mounted = true;
@@ -183,6 +196,7 @@ export function AuthProvider({ children }) {
       switchUser,
       lock,
       clearJustSignedIn,
+      resetAppData,
     }),
     [
       status,
@@ -194,6 +208,7 @@ export function AuthProvider({ children }) {
       lockedUser,
       justSignedIn,
       clearJustSignedIn,
+      resetAppData,
     ],
   );
 

--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -1,12 +1,21 @@
 import React, { useEffect, useRef, useState } from "react";
-import { ChevronDown, LogOut, RefreshCcw, Shield, Users } from "lucide-react";
+import { ChevronDown, LogOut, RefreshCcw, Shield, Trash2, Users } from "lucide-react";
 
-function MenuItem({ icon: Icon, label, onClick, disabled }) {
+function MenuItem({ icon: Icon, label, onClick, disabled, variant = "default", buttonRef }) {
+  const classes = (() => {
+    if (variant === "destructive") {
+      return disabled
+        ? "cursor-not-allowed text-red-300"
+        : "text-red-600 hover:bg-red-50";
+    }
+    return disabled
+      ? "cursor-not-allowed text-slate-400"
+      : "text-slate-700 hover:bg-slate-100";
+  })();
   return (
     <button
-      className={`w-full flex items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${
-        disabled ? "cursor-not-allowed text-slate-400" : "hover:bg-slate-100 text-slate-700"
-      }`}
+      ref={buttonRef}
+      className={`w-full flex items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${classes}`}
       onClick={onClick}
       type="button"
       disabled={disabled}
@@ -17,7 +26,15 @@ function MenuItem({ icon: Icon, label, onClick, disabled }) {
   );
 }
 
-export default function UserMenu({ user, onLock, onSignOut, onSwitchUser, onSync }) {
+export default function UserMenu({
+  user,
+  onLock,
+  onSignOut,
+  onSwitchUser,
+  onSync,
+  onClearLocalData,
+  clearDataButtonRef,
+}) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef(null);
 
@@ -87,6 +104,19 @@ export default function UserMenu({ user, onLock, onSignOut, onSwitchUser, onSync
               setOpen(false);
             }}
           />
+          <div className="mt-3 border-t border-slate-200 pt-3">
+            <div className="mb-2 text-xs uppercase tracking-wide text-slate-400">Developer</div>
+            <MenuItem
+              icon={Trash2}
+              label="Clear local data"
+              variant="destructive"
+              onClick={() => {
+                onClearLocalData?.();
+                setOpen(false);
+              }}
+              buttonRef={clearDataButtonRef}
+            />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add a resetAppData helper in the auth context so the app can clear stored data
- add a developer reset confirmation flow in the workspace tied into the user menu
- extend the user menu with a developer section and clear local data action

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e32ec6ac94832380d1d5176ada9cd9