### PR TITLE
Fix modal input focus stability and add regression tests

### DIFF
--- a/src/__tests__/modal.focus.test.jsx
+++ b/src/__tests__/modal.focus.test.jsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React, { useRef, useState } from "react";
+
+import { ReportSetup } from "../App.jsx";
+import FsrEntriesSection from "../components/FsrEntriesSection.jsx";
+
+describe("modal input focus", () => {
+  it("keeps focus in the Create Report modal while typing", async () => {
+    const controls = {};
+    const user = userEvent.setup();
+
+    function Harness({ expose }) {
+      const [open, setOpen] = useState(false);
+      const [tick, setTick] = useState(false);
+      const triggerRef = useRef(null);
+
+      const handleCreate = () => {};
+
+      if (expose) {
+        expose({
+          openModal: () => setOpen(true),
+          triggerExternalUpdate: () => setTick((prev) => !prev),
+        });
+      }
+
+      return (
+        <div>
+          <button ref={triggerRef} onClick={() => setOpen(true)}>
+            Open setup
+          </button>
+          <span aria-hidden="true">{tick ? "on" : "off"}</span>
+          <ReportSetup
+            open={open}
+            onClose={() => setOpen(false)}
+            types={["Service", "Maintenance"]}
+            onCreate={handleCreate}
+            returnFocusRef={triggerRef}
+          />
+        </div>
+      );
+    }
+
+    render(<Harness expose={(api) => Object.assign(controls, api)} />);
+
+    await act(async () => {
+      controls.openModal();
+    });
+
+    const jobInput = await screen.findByLabelText(/job/i);
+    await user.clear(jobInput);
+    await user.type(jobInput, "12345");
+    expect(jobInput).toHaveValue("J#12345");
+    expect(document.activeElement).toBe(jobInput);
+
+    await act(async () => {
+      controls.triggerExternalUpdate();
+    });
+
+    expect(jobInput).toHaveValue("J#12345");
+    expect(document.activeElement).toBe(jobInput);
+  });
+
+  it("keeps focus in the Add Entry modal while typing", async () => {
+    const controls = {};
+    const user = userEvent.setup();
+
+    function Harness({ expose }) {
+      const [entries, setEntries] = useState([]);
+      const [extras, setExtras] = useState([]);
+
+      const handleAddEntry = (entry) => {
+        setEntries((prev) => [...prev, { ...entry, id: entry.id || `entry-${prev.length}` }]);
+      };
+
+      const noop = () => {};
+
+      if (expose) {
+        expose({
+          addExternalItem: () => setExtras((prev) => [...prev, prev.length]),
+        });
+      }
+
+      return (
+        <div>
+          <FsrEntriesSection
+            entries={entries}
+            onAddEntry={handleAddEntry}
+            onUpdateEntry={noop}
+            onRemoveEntry={noop}
+            onMoveEntry={noop}
+            onCollapseAll={noop}
+            readyForIssue
+          />
+          <ul aria-hidden="true">
+            {extras.map((item) => (
+              <li key={item}>extra-{item}</li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    render(<Harness expose={(api) => Object.assign(controls, api)} />);
+
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    const dialogs = await screen.findAllByRole("dialog");
+    const dialog = dialogs[dialogs.length - 1];
+    await user.click(within(dialog).getByRole("button", { name: /issue/i }));
+
+    const textarea = within(dialog).getByPlaceholderText(/what happened/i);
+    await user.type(textarea, "abcdef");
+    expect(textarea).toHaveValue("abcdef");
+    expect(document.activeElement).toBe(textarea);
+
+    await act(async () => {
+      controls.addExternalItem();
+    });
+
+    expect(textarea).toHaveValue("abcdef");
+    expect(document.activeElement).toBe(textarea);
+  });
+});

--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -14,8 +14,18 @@ function ConfirmDialog({
   const containerRef = useRef(null);
   useModalA11y(open, containerRef, { onClose: onCancel, returnFocusRef });
   if (!open) return null;
+  const handleOverlayMouseDown = (event) => {
+    if (event.target === event.currentTarget) {
+      onCancel?.();
+    }
+  };
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="alertdialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="alertdialog"
+      aria-modal="true"
+      onMouseDown={handleOverlayMouseDown}
+    >
       <div ref={containerRef} tabIndex={-1} className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
         <h3 className="text-lg font-bold">{title}</h3>
         <p className="mt-2 text-sm text-gray-600">{message}</p>

--- a/src/components/FsrEntriesSection.jsx
+++ b/src/components/FsrEntriesSection.jsx
@@ -543,7 +543,16 @@ function FsrEntriesSection({
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4" role="dialog" aria-modal="true">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+          role="dialog"
+          aria-modal="true"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              closeModal();
+            }
+          }}
+        >
           <div ref={modalContainerRef} tabIndex={-1} className="w-full max-w-3xl rounded-3xl bg-white p-6 shadow-xl">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-xl font-semibold">

--- a/src/components/ManageDocsModal.jsx
+++ b/src/components/ManageDocsModal.jsx
@@ -54,8 +54,18 @@ function ManageDocsModal({ open, onClose, documents, onChange, returnFocusRef })
   const containerRef = useRef(null);
   useModalA11y(open, containerRef, { onClose, returnFocusRef });
   if (!open) return null;
+  const handleOverlayMouseDown = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose?.();
+    }
+  };
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={handleOverlayMouseDown}
+    >
       <div ref={containerRef} tabIndex={-1} className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-xl font-bold">Documents</h3>

--- a/src/components/ManageTypes.jsx
+++ b/src/components/ManageTypes.jsx
@@ -8,8 +8,18 @@ function ManageTypes({ open, onClose, types, setTypes, returnFocusRef, storage }
   const containerRef = useRef(null);
   useModalA11y(open, containerRef, { onClose, returnFocusRef });
   if (!open) return null;
+  const handleOverlayMouseDown = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose?.();
+    }
+  };
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={handleOverlayMouseDown}
+    >
       <div ref={containerRef} tabIndex={-1} className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-xl font-bold">Manage Trip Types</h3>

--- a/src/components/ManualsModal.jsx
+++ b/src/components/ManualsModal.jsx
@@ -9,8 +9,19 @@ function ManualsModal({ open, onClose, model, returnFocusRef }) {
 
   const trimmedModel = (model || "").trim();
 
+  const handleOverlayMouseDown = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose?.();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={handleOverlayMouseDown}
+    >
       <div ref={containerRef} tabIndex={-1} className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-xl">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- refactor the Create Report modal to manage a local draft, stabilize its mounting behavior, and add accessible form labels
- harden the shared modal focus trap and overlays so modals stay focused while typing and close only on intentional actions
- update quick-add and admin modals to use the improved patterns and add regression tests covering report creation and FSR entry modals

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`

## Checklist
- [x] Lint
- [x] Tests
- [x] Build

------
https://chatgpt.com/codex/tasks/task_e_68e3343213088323a6b1f4f0bbe9d1e9